### PR TITLE
Change case of CursorMoveDirection enum values

### DIFF
--- a/src/main/kotlin/org/treeWare/model/cursor/CursorMoveDirection.kt
+++ b/src/main/kotlin/org/treeWare/model/cursor/CursorMoveDirection.kt
@@ -1,3 +1,3 @@
 package org.treeWare.model.cursor
 
-enum class CursorMoveDirection { Visit, Leave }
+enum class CursorMoveDirection { VISIT, LEAVE }

--- a/src/main/kotlin/org/treeWare/model/cursor/FollowerModelCursorMove.kt
+++ b/src/main/kotlin/org/treeWare/model/cursor/FollowerModelCursorMove.kt
@@ -14,37 +14,37 @@ sealed class FollowerModelCursorMove<Aux>(val direction: CursorMoveDirection) {
 }
 
 class VisitFollowerModel<Aux>(override val element: Model<Aux>?) :
-    FollowerModelCursorMove<Aux>(CursorMoveDirection.Visit)
+    FollowerModelCursorMove<Aux>(CursorMoveDirection.VISIT)
 
 class LeaveFollowerModel<Aux>(override val element: Model<Aux>?) :
-    FollowerModelCursorMove<Aux>(CursorMoveDirection.Leave)
+    FollowerModelCursorMove<Aux>(CursorMoveDirection.LEAVE)
 
 class VisitFollowerRootModel<Aux>(override val element: RootModel<Aux>?) :
-    FollowerModelCursorMove<Aux>(CursorMoveDirection.Visit)
+    FollowerModelCursorMove<Aux>(CursorMoveDirection.VISIT)
 
 class LeaveFollowerRootModel<Aux>(override val element: RootModel<Aux>?) :
-    FollowerModelCursorMove<Aux>(CursorMoveDirection.Leave)
+    FollowerModelCursorMove<Aux>(CursorMoveDirection.LEAVE)
 
 class VisitFollowerEntityModel<Aux>(override val element: EntityModel<Aux>?) :
-    FollowerModelCursorMove<Aux>(CursorMoveDirection.Visit)
+    FollowerModelCursorMove<Aux>(CursorMoveDirection.VISIT)
 
 class LeaveFollowerEntityModel<Aux>(override val element: EntityModel<Aux>?) :
-    FollowerModelCursorMove<Aux>(CursorMoveDirection.Leave)
+    FollowerModelCursorMove<Aux>(CursorMoveDirection.LEAVE)
 
 class VisitFollowerFieldModel<Aux>(override val element: FieldModel<Aux>?) :
-    FollowerModelCursorMove<Aux>(CursorMoveDirection.Visit)
+    FollowerModelCursorMove<Aux>(CursorMoveDirection.VISIT)
 
 class LeaveFollowerFieldModel<Aux>(override val element: FieldModel<Aux>?) :
-    FollowerModelCursorMove<Aux>(CursorMoveDirection.Leave)
+    FollowerModelCursorMove<Aux>(CursorMoveDirection.LEAVE)
 
 class VisitFollowerListFieldModel<Aux>(override val element: FieldModel<Aux>?) :
-    FollowerModelCursorMove<Aux>(CursorMoveDirection.Visit)
+    FollowerModelCursorMove<Aux>(CursorMoveDirection.VISIT)
 
 class LeaveFollowerListFieldModel<Aux>(override val element: FieldModel<Aux>?) :
-    FollowerModelCursorMove<Aux>(CursorMoveDirection.Leave)
+    FollowerModelCursorMove<Aux>(CursorMoveDirection.LEAVE)
 
 class VisitFollowerEntityKeysModel<Aux>(override val element: EntityKeysModel<Aux>?) :
-    FollowerModelCursorMove<Aux>(CursorMoveDirection.Visit)
+    FollowerModelCursorMove<Aux>(CursorMoveDirection.VISIT)
 
 class LeaveFollowerEntityKeysModel<Aux>(override val element: EntityKeysModel<Aux>?) :
-    FollowerModelCursorMove<Aux>(CursorMoveDirection.Leave)
+    FollowerModelCursorMove<Aux>(CursorMoveDirection.LEAVE)

--- a/src/main/kotlin/org/treeWare/model/cursor/LeaderModelCursorMove.kt
+++ b/src/main/kotlin/org/treeWare/model/cursor/LeaderModelCursorMove.kt
@@ -14,37 +14,37 @@ sealed class LeaderModelCursorMove<Aux>(val direction: CursorMoveDirection) {
 }
 
 class VisitLeaderModel<Aux>(override val element: Model<Aux>) :
-    LeaderModelCursorMove<Aux>(CursorMoveDirection.Visit)
+    LeaderModelCursorMove<Aux>(CursorMoveDirection.VISIT)
 
 class LeaveLeaderModel<Aux>(override val element: Model<Aux>) :
-    LeaderModelCursorMove<Aux>(CursorMoveDirection.Leave)
+    LeaderModelCursorMove<Aux>(CursorMoveDirection.LEAVE)
 
 class VisitLeaderRootModel<Aux>(override val element: RootModel<Aux>) :
-    LeaderModelCursorMove<Aux>(CursorMoveDirection.Visit)
+    LeaderModelCursorMove<Aux>(CursorMoveDirection.VISIT)
 
 class LeaveLeaderRootModel<Aux>(override val element: RootModel<Aux>) :
-    LeaderModelCursorMove<Aux>(CursorMoveDirection.Leave)
+    LeaderModelCursorMove<Aux>(CursorMoveDirection.LEAVE)
 
 class VisitLeaderEntityModel<Aux>(override val element: EntityModel<Aux>) :
-    LeaderModelCursorMove<Aux>(CursorMoveDirection.Visit)
+    LeaderModelCursorMove<Aux>(CursorMoveDirection.VISIT)
 
 class LeaveLeaderEntityModel<Aux>(override val element: EntityModel<Aux>) :
-    LeaderModelCursorMove<Aux>(CursorMoveDirection.Leave)
+    LeaderModelCursorMove<Aux>(CursorMoveDirection.LEAVE)
 
 class VisitLeaderFieldModel<Aux>(override val element: FieldModel<Aux>) :
-    LeaderModelCursorMove<Aux>(CursorMoveDirection.Visit)
+    LeaderModelCursorMove<Aux>(CursorMoveDirection.VISIT)
 
 class LeaveLeaderFieldModel<Aux>(override val element: FieldModel<Aux>) :
-    LeaderModelCursorMove<Aux>(CursorMoveDirection.Leave)
+    LeaderModelCursorMove<Aux>(CursorMoveDirection.LEAVE)
 
 class VisitLeaderListFieldModel<Aux>(override val element: FieldModel<Aux>) :
-    LeaderModelCursorMove<Aux>(CursorMoveDirection.Visit)
+    LeaderModelCursorMove<Aux>(CursorMoveDirection.VISIT)
 
 class LeaveLeaderListFieldModel<Aux>(override val element: FieldModel<Aux>) :
-    LeaderModelCursorMove<Aux>(CursorMoveDirection.Leave)
+    LeaderModelCursorMove<Aux>(CursorMoveDirection.LEAVE)
 
 class VisitLeaderEntityKeysModel<Aux>(override val element: EntityKeysModel<Aux>) :
-    LeaderModelCursorMove<Aux>(CursorMoveDirection.Visit)
+    LeaderModelCursorMove<Aux>(CursorMoveDirection.VISIT)
 
 class LeaveLeaderEntityKeysModel<Aux>(override val element: EntityKeysModel<Aux>) :
-    LeaderModelCursorMove<Aux>(CursorMoveDirection.Leave)
+    LeaderModelCursorMove<Aux>(CursorMoveDirection.LEAVE)

--- a/src/main/kotlin/org/treeWare/model/operator/Leader1Follower0ModelForEach.kt
+++ b/src/main/kotlin/org/treeWare/model/operator/Leader1Follower0ModelForEach.kt
@@ -14,8 +14,8 @@ fun <LeaderAux> forEach(
     while (action != TraversalAction.ABORT_TREE) {
         val leaderMove = leaderCursor.next(action) ?: break
         action = when (leaderMove.direction) {
-            CursorMoveDirection.Visit -> dispatchVisit(leaderMove.element, visitor) ?: TraversalAction.ABORT_TREE
-            CursorMoveDirection.Leave -> {
+            CursorMoveDirection.VISIT -> dispatchVisit(leaderMove.element, visitor) ?: TraversalAction.ABORT_TREE
+            CursorMoveDirection.LEAVE -> {
                 dispatchLeave(leaderMove.element, visitor)
                 TraversalAction.CONTINUE
             }

--- a/src/main/kotlin/org/treeWare/model/operator/Leader1Follower1ModelForEach.kt
+++ b/src/main/kotlin/org/treeWare/model/operator/Leader1Follower1ModelForEach.kt
@@ -21,9 +21,9 @@ fun <LeaderAux, FollowerAux> forEach(
         if (followerMove == null) break
         println("#### followerMove.element: ${followerMove.element?.elementType}")
         action = when (leaderMove.direction) {
-            CursorMoveDirection.Visit -> dispatchVisit(leaderMove.element, followerMove.element, visitor)
+            CursorMoveDirection.VISIT -> dispatchVisit(leaderMove.element, followerMove.element, visitor)
                 ?: TraversalAction.ABORT_TREE
-            CursorMoveDirection.Leave -> {
+            CursorMoveDirection.LEAVE -> {
                 dispatchLeave(leaderMove.element, followerMove.element, visitor)
                 TraversalAction.CONTINUE
             }

--- a/src/main/kotlin/org/treeWare/model/operator/Leader1Follower2ModelForEach.kt
+++ b/src/main/kotlin/org/treeWare/model/operator/Leader1Follower2ModelForEach.kt
@@ -25,13 +25,13 @@ suspend fun <LeaderAux, Follower1Aux, Follower2Aux> forEach(
         assert(follower2Move != null)
         if (follower2Move == null) break
         action = when (leaderMove.direction) {
-            CursorMoveDirection.Visit -> dispatchVisit(
+            CursorMoveDirection.VISIT -> dispatchVisit(
                 leaderMove.element,
                 follower1Move.element,
                 follower2Move.element,
                 visitor
             ) ?: TraversalAction.ABORT_TREE
-            CursorMoveDirection.Leave -> {
+            CursorMoveDirection.LEAVE -> {
                 dispatchLeave(leaderMove.element, follower1Move.element, follower2Move.element, visitor)
                 TraversalAction.CONTINUE
             }

--- a/src/test/kotlin/org/treeWare/model/cursor/FollowerModelCursorTests.kt
+++ b/src/test/kotlin/org/treeWare/model/cursor/FollowerModelCursorTests.kt
@@ -108,9 +108,9 @@ private fun testFollowerWildcardModelInstance(leaderFilePath: String, wildcardFi
         assertNotNull(followerMove)
 
         action = when (leaderMove.direction) {
-            CursorMoveDirection.Visit -> dispatchVisit(leaderMove.element, encodingVisitor)
+            CursorMoveDirection.VISIT -> dispatchVisit(leaderMove.element, encodingVisitor)
                 ?: TraversalAction.ABORT_TREE
-            CursorMoveDirection.Leave -> {
+            CursorMoveDirection.LEAVE -> {
                 dispatchLeave(leaderMove.element, encodingVisitor)
                 TraversalAction.CONTINUE
             }


### PR DESCRIPTION
The Kotlin style guide permits SCREAMING_SNAKE_CASE or CamelCase for
enum values. CursorMoveDirection was using CamelCase but all other
enums are using SCREAMING_SNAKE_CASE. CursorMoveDirection enum values
are now changed to SCREAMING_SNAKE_CASE for consistency sake.