### PR TITLE
Create an aux instance before decoding it

### DIFF
--- a/src/main/kotlin/org/treeWare/model/codec/decoder/stateMachine/BaseEntityStateMachine.kt
+++ b/src/main/kotlin/org/treeWare/model/codec/decoder/stateMachine/BaseEntityStateMachine.kt
@@ -91,6 +91,7 @@ class BaseEntityStateMachine<Aux>(
             if (auxStateMachine != null) {
                 auxStateMachineMap[fieldName] = auxStateMachine
                 stack.addFirst(auxStateMachine)
+                auxStateMachine.newAux()
             } else stack.addFirst(SkipUnknownStateMachine<Aux>(stack))
             return true
         }

--- a/src/main/kotlin/org/treeWare/model/codec/decoder/stateMachine/RootModelStateMachine.kt
+++ b/src/main/kotlin/org/treeWare/model/codec/decoder/stateMachine/RootModelStateMachine.kt
@@ -50,6 +50,7 @@ class RootModelStateMachine<Aux>(
             if (fieldAndAuxNames?.fieldName == root.schema.name) {
                 // TODO(deepak-nulu): also validate auxName.
                 stack.addFirst(auxStateMachine)
+                auxStateMachine.newAux()
                 return true
             }
         }

--- a/src/main/kotlin/org/treeWare/model/codec/decoder/stateMachine/ScalarFieldModelStateMachine.kt
+++ b/src/main/kotlin/org/treeWare/model/codec/decoder/stateMachine/ScalarFieldModelStateMachine.kt
@@ -11,7 +11,6 @@ class ScalarFieldModelStateMachine<Aux>(
     private val stack: DecodingStack,
     auxStateMachineFactory: () -> AuxDecodingStateMachine<Aux>?
 ) : ValueDecodingStateMachine<Aux>, AbstractDecodingStateMachine(true) {
-    private val auxStateMachine = auxStateMachineFactory()
     private var field: MutableScalarFieldModel<Aux>? = null
     private val logger = LogManager.getLogger()
 


### PR DESCRIPTION
ValueAndAuxStateMachine used to handle all decoding of aux data, but
after the simplification of the JSON representation, other state-
machines also need to create aux instances before they are decoded.