### PR TITLE
Log meta-model full-names at INFO level

### DIFF
--- a/src/main/kotlin/org/treeWare/metaModel/validation/ValidateNames.kt
+++ b/src/main/kotlin/org/treeWare/metaModel/validation/ValidateNames.kt
@@ -21,7 +21,7 @@ fun validateNames(mainMeta: MutableMainModel, logFullNames: Boolean): List<Strin
 
     if (logFullNames) {
         val logger = LogManager.getLogger()
-        state.fullNames.forEach { logger.debug("element fullName: $it") }
+        state.fullNames.forEach { logger.info("element fullName: $it") }
     }
     return state.errors
 }


### PR DESCRIPTION
A flag controls whether meta-model full-names are to be logged or not,
so they can be logged at INFO level instead of DEBUG level.