### PR TITLE
Permit deletion of keyless entities without any fields

### DIFF
--- a/src/commonMain/kotlin/org/treeWare/model/core/Model.kt
+++ b/src/commonMain/kotlin/org/treeWare/model/core/Model.kt
@@ -7,6 +7,7 @@ interface ElementModel {
     val auxs: Map<String, Any>?
 
     fun setAux(auxName: String, aux: Any) // TODO(#77): remove when #77 is implemented
+    fun unsetAux(auxName: String)
     fun matches(that: ElementModel): Boolean
 }
 

--- a/src/commonMain/kotlin/org/treeWare/model/core/MutableModel.kt
+++ b/src/commonMain/kotlin/org/treeWare/model/core/MutableModel.kt
@@ -17,6 +17,10 @@ abstract class MutableElementModel : ElementModel {
         if (auxsInternal == null) auxsInternal = LinkedHashMap()
         auxsInternal?.also { it[auxName] = aux }
     }
+
+    override fun unsetAux(auxName: String) {
+        auxsInternal?.also { it.remove(auxName) }
+    }
 }
 
 class MutableMainModel(override val mainMeta: MainModel?) :
@@ -451,6 +455,7 @@ class MutableAssociationModel(
     // overridden to make this possible.
     override val auxs: Map<String, Any>? get() = value.auxs
     override fun setAux(auxName: String, aux: Any) = value.setAux(auxName, aux)
+    override fun unsetAux(auxName: String) = value.unsetAux(auxName)
 }
 
 // Helpers

--- a/src/commonMain/kotlin/org/treeWare/model/operator/set/aux/SetAux.kt
+++ b/src/commonMain/kotlin/org/treeWare/model/operator/set/aux/SetAux.kt
@@ -16,3 +16,7 @@ fun getSetAux(element: ElementModel?): SetAux? = element?.getAux(SET_AUX_NAME)
 fun setSetAux(element: ElementModel, aux: SetAux) {
     element.setAux(SET_AUX_NAME, aux)
 }
+
+fun unsetSetAux(element: ElementModel) {
+    element.unsetAux(SET_AUX_NAME)
+}

--- a/src/jvmMain/kotlin/org/treeWare/model/operator/Print.kt
+++ b/src/jvmMain/kotlin/org/treeWare/model/operator/Print.kt
@@ -1,13 +1,25 @@
 package org.treeWare.model.operator
 
 import org.treeWare.model.core.ElementModel
+import org.treeWare.model.encoder.AuxEncoder
+import org.treeWare.model.encoder.MultiAuxEncoder
 import org.treeWare.model.encoder.encodeJson
+import org.treeWare.model.operator.rbac.aux.PERMISSIONS_AUX_NAME
+import org.treeWare.model.operator.rbac.aux.PermissionsAuxEncoder
+import org.treeWare.model.operator.set.aux.SET_AUX_NAME
+import org.treeWare.model.operator.set.aux.SetAuxEncoder
 import java.io.PrintWriter
 
-fun print(description: String, element: ElementModel) {
+private val coreAuxEncoders = arrayOf(
+    SET_AUX_NAME to SetAuxEncoder(),
+    PERMISSIONS_AUX_NAME to PermissionsAuxEncoder()
+)
+
+fun print(description: String, element: ElementModel, vararg nonCoreAuxEncoders: Pair<String, AuxEncoder>) {
     println("$description:")
     val printWriter = PrintWriter(System.out)
-    val success = encodeJson(element, printWriter, prettyPrint = true)
+    val multiAuxEncoder = MultiAuxEncoder(*coreAuxEncoders, *nonCoreAuxEncoders)
+    val success = encodeJson(element, printWriter, multiAuxEncoder, prettyPrint = true)
     printWriter.flush()
     println() // since encodeJson() ends without a new line.
     println("$description encoding succeeded: $success")

--- a/src/jvmTest/kotlin/org/treeWare/model/operator/PermitSetTests.kt
+++ b/src/jvmTest/kotlin/org/treeWare/model/operator/PermitSetTests.kt
@@ -43,6 +43,7 @@ class PermitSetTests {
             setJson,
             multiAuxDecodingStateMachineFactory = multiAuxDecodingFactory
         )
+        assertMatchesJsonString(setModel, setJson, EncodePasswords.ALL, multiAuxEncoder)
         val actual = permitSet(setModel, rbac)
         if (expectedPermittedJson == null) {
             when (actual) {
@@ -159,6 +160,27 @@ class PermitSetTests {
             |          "name": "New York City",
             |          "state": "New York",
             |          "country": "United States of America"
+            |        }
+            |      }
+            |    ]
+            |  }
+            |}
+        """.trimMargin()
+        val rbac = newRootRbac(PermissionsAux(crud = PermissionScope.SUB_TREE))
+        testPermitSet(deleteEntitiesSetJson, rbac, expectedPermittedJson = deleteEntitiesSetJson, true)
+    }
+
+    @Test
+    fun `DELETE keyless entities without any fields in set-model must not be pruned by the permitSet operator`() {
+        val deleteEntitiesSetJson = """
+            |{
+            |  "address_book": {
+            |    "person": [
+            |      {
+            |        "set_": "delete",
+            |        "id": "cc477201-48ec-4367-83a4-7fdbd92f8a6f",
+            |        "hero_details": {
+            |          "set_": "delete"
             |        }
             |      }
             |    ]


### PR DESCRIPTION
Keyless entities without any fields in a delete-requests were getting
pruned by the permitSet() operator. They should not be pruned. This
commit ensures that they are not pruned.