### PR TITLE
Use the same version for all libraries in the repo

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,11 @@
-group = "org.tree-ware.tree-ware-kotlin-core"
-version = "0.1.0.1"
+// The libraries are currently published to JitPack. JitPack picks up the
+// version from the repo label, resulting in all libraries from the repo
+// having the same version in JitPack. Setting the version for all projects
+// conveys this.
+allprojects {
+    group = "org.tree-ware.tree-ware-kotlin-core"
+    version = "0.1.0.2"
+}
 
 val jbcryptVersion = "0.4"
 val jsonVersion = "1.1.4"

--- a/test-fixtures/build.gradle.kts
+++ b/test-fixtures/build.gradle.kts
@@ -1,11 +1,8 @@
-group = "org.tree-ware.tree-ware-kotlin-core"
-version = "0.1.0.0"
-
 val log4j2Version = "2.16.0"
 val mockkVersion = "1.12.0"
 
 plugins {
-    kotlin("multiplatform")
+    kotlin("multiplatform") version "1.7.0"
     id("maven-publish")
 }
 


### PR DESCRIPTION
The libraries are currently published to JitPack. JitPack picks up the version from the repo label, resulting in all libraries from the repo having the same version in JitPack. Setting the version for all projects conveys this.